### PR TITLE
[macOS Sample App] Remove not needed keychain sharing group

### DIFF
--- a/NativeAuthSampleAppMacOS/NativeAuthSampleAppMacOS.entitlements
+++ b/NativeAuthSampleAppMacOS/NativeAuthSampleAppMacOS.entitlements
@@ -10,7 +10,6 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.microsoft.NativeAuthSampleAppMacOS</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.identity.universalstorage</string>
 	</array>
 </dict>


### PR DESCRIPTION
## Purpose
As per the Native Auth [documentation](https://learn.microsoft.com/en-us/entra/msal/objc/howto-v2-keychain-objc?tabs=objc#macos), the only entitlement needed for storing and retrieving access token, is adding the share bundleId `com.microsoft.identity.universalstorage` in the  keychain sharing so the app one can be removed

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
